### PR TITLE
No longer registering Jade's built-in plugins

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,9 +31,7 @@
       "com.llamalad7.mixinextras.MixinExtrasBootstrap::init"
     ],
     "jade": [
-      "net.larsmans.infinitybuttons.compat.jade.InfinityButtonsPlugin",
-      "snownee.jade.addon.vanilla.VanillaPlugin",
-      "snownee.jade.addon.universal.UniversalPlugin"
+      "net.larsmans.infinitybuttons.compat.jade.InfinityButtonsPlugin"
     ]
   },
   "mixins": [


### PR DESCRIPTION
Jade's built-in plugins should not be registered in third party mods. This will cause a crash since Jade 11.9.1